### PR TITLE
Adds auto test run for PRs

### DIFF
--- a/.github/workflows/automated_test.yml
+++ b/.github/workflows/automated_test.yml
@@ -1,26 +1,25 @@
 name: Test Faker EDU
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ["3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install faker
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pip install pytest-cov
-        pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install faker
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest


### PR DESCRIPTION
This is meant to trigger testing when a PR is openned.  The current push settings don't trigger when people without write access to this project submit code.

The PR also includes a linter clean up of the workflow file which I intend to test by opening this PR (I think it's all fine, but we should be sure).